### PR TITLE
Fix possible division by zero in interpolation function

### DIFF
--- a/mpy_robot_tools/motor_sync.py
+++ b/mpy_robot_tools/motor_sync.py
@@ -37,6 +37,11 @@ def linear_interpolation(points, wrapping=True, scale=1, accumulation=True, time
     x_max = points[-1][0]
     x_range = x_max - x_min
 
+    if x_range == 0:
+        def zero_function(x):
+            return 0
+        return zero_function
+
     # Now rebase to x's 0 and invert values if needed
     points = [(x - x_min, scale * y) for (x, y) in points]
 
@@ -91,6 +96,8 @@ def linear_interpolation(points, wrapping=True, scale=1, accumulation=True, time
                     smooth_progress = 0
                 interpolated_y = y1 + smoothing*smooth_progress*gap + (1-smoothing)*progress*gap
                 return x_periods*accumulation_per_period + interpolated_y * scale
+
+        return 0 # Just in case
     return function
 
 def linear(factor, time_delay = 0, offset = 0):

--- a/mpy_robot_tools/motor_sync.py
+++ b/mpy_robot_tools/motor_sync.py
@@ -12,7 +12,7 @@ def linear_interpolation(points, wrapping=True, scale=1, accumulation=True, time
     Returns: A method(!) that interpolates a value between given points
 
     Arguments:
-    - scale_y: scale the y coordinates to enlarge movements or to invert them (scale_y=-1)
+    - scale: scale the y coordinates to enlarge movements or to invert them (scale=-1)
     - wrapping: True by default. If an x value is beyond the highest x value in the point list,
     wrapping will wrap the values and look back to the first coordinates.
     - accumulation: Boolean. True, by default. After each wraparound, 


### PR DESCRIPTION
If someone create keyframe with single tuple of (0, 0) there will be an error of division by zero. This pull request offers simple fix for this issue. It also fixes a little documentation of interpolation function.