### PR TITLE
increase servo resolution

### DIFF
--- a/mpy_robot_tools/servo.py
+++ b/mpy_robot_tools/servo.py
@@ -46,9 +46,8 @@ class Servo:
         :param pwm: microseconds pulse width.
         :type pwm: int or float
         """
-        ONE_US = 1024 / 20000
         pwm = min(max(pwm, self.min_pulse), self.max_pulse)
-        self.servo.duty(round(pwm * ONE_US))
+        self.servo.duty_u16(int(pwm*3.2768))
 
     def angle(self, angle:float) -> None:
         """Set servo angle. Values are capped between min_angle and max_angle, as set at init.


### PR DESCRIPTION
for a servo with min_pulse=500, max_pulse=2500, min_angle=0, max_angle=360 the resolution was only 3-4°

angle pulse duty duty_u16
   0   500   26   1638
   1   505   26   1656
   2   511   26   1674
   3   516   26   1693
   4   522   27   1711
   5   527   27   1729
   6   533   27   1747
   7   538   28   1765
   8   544   28   1784
   9   550   28   1802
  10   555   28   1820
  11   561   29   1838